### PR TITLE
Display location on map component.

### DIFF
--- a/src/components/EventDetails.js
+++ b/src/components/EventDetails.js
@@ -75,6 +75,8 @@ export const EventDetails = (props) => {
             : null
           }
           <SimpleMap
+            coordinates={props.event.venue_location}
+            venueName={props.event.venue.name}
             containerElement={
               <div className='map-container-element' />
             }

--- a/src/components/SimpleMap.js
+++ b/src/components/SimpleMap.js
@@ -1,9 +1,18 @@
 import React from 'react';
-import { withGoogleMap, GoogleMap } from 'react-google-maps';
+import { withGoogleMap, GoogleMap, Marker } from 'react-google-maps';
+
+const DEFAULT_COORDS = { lat: 43.653, lng: -79.383 };
 
 export const SimpleMap = withGoogleMap(props => (
   <GoogleMap
     defaultZoom={12}
-    defaultCenter={{ lat: 43.653, lng: -79.383 }}
-  />
+    defaultCenter={props.coordinates ? props.coordinates : DEFAULT_COORDS }
+  >
+    {
+      (props.coordinates) ?
+        <Marker position={props.coordinates}
+                label={props.venueName ? props.venueName : ""} />
+        : null
+    }
+  </GoogleMap>
 ));

--- a/src/redux/epics/event.epics.js
+++ b/src/redux/epics/event.epics.js
@@ -50,7 +50,7 @@ export const getEventEpic = (action$, _, {ajax}) =>
   action$.ofType(ACTION_TYPES.GET_EVENT)
     .mergeMap(action =>
       ajax({
-        url: `${BASE_ENDPOINT}${action.payload}/${API_KEY_PATH}`,
+        url: `${BASE_ENDPOINT}${action.payload}/${API_KEY_PATH}&expand=venue`,
         crossDomain: true
       })
         .map(({ response }) => ({

--- a/src/redux/reducers/event.reducer.js
+++ b/src/redux/reducers/event.reducer.js
@@ -13,7 +13,15 @@ export const eventReducer = (state = DEFAULT_STATE, action) => {
     case ACTION_TYPES.GET_EVENT:
       return {...state, isFetching: true};
     case ACTION_TYPES.SET_EVENT:
-      return {...state, event: action.payload, isFetching: false, didInvalidate: false}
+      let event = action.payload;
+      if (action.payload.venue.address.latitude && action.payload.venue.address.longitude) {
+        let venue_location = {
+          lat: parseFloat(action.payload.venue.address.latitude),
+          lng: parseFloat(action.payload.venue.address.longitude)
+        };
+        event = {...event, venue_location};
+      }
+      return {...state, event: event, isFetching: false, didInvalidate: false};
     case ACTION_TYPES.SET_EVENT_INVALIDATE:
       return {...state, isFetching: false, didInvalidate: true, event: null}
     case ACTION_TYPES.UPDATE_EVENT_DETAIL_RENDER:
@@ -21,7 +29,4 @@ export const eventReducer = (state = DEFAULT_STATE, action) => {
     default:
       return state;
   }
-}
-
-
-
+};

--- a/src/tests/components/EventDetails.test.js
+++ b/src/tests/components/EventDetails.test.js
@@ -21,12 +21,34 @@ describe('EventDetails component tests', () => {
       is_free:  false,
       logo : {
         url: "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F28253674%2F183837305730%2F1%2Foriginal.jpg?h=200&w=450&rect=0%2C0%2C1000%2C500&s=b42f77f4a43a35ab28df4b3276da3494",
+      },
+      venue: {
+        address: {
+          address_1: "5875 Airport Road",
+          address_2: null,
+          city: "Mississauga",
+          region: "ON",
+          postal_code: "L4V 1N1",
+          country: "CA",
+          latitude: "43.686773",
+          longitude: "-79.60380499999997",
+          localized_address_display: "5875 Airport Road, Mississauga, ON L4V 1N1",
+          localized_area_display: "Mississauga, ON",
+          localized_multi_line_address_display: [
+            "5875 Airport Road",
+            "Mississauga, ON L4V 1N1"
+          ]
+        },
+        resource_uri: "https://www.eventbriteapi.com/v3/venues/20442514/",
+        id: "20442514",
+        name: "Hilton Toronto Airport Hotel & Suites",
+        latitude: "43.686773",
+        longitude: "-79.60380499999997"
       }
   }};
 
   it('renders without crashing', () => {
     const wrapper = shallow(<EventDetails {...props}/>);
-
     expect(wrapper.find('div')).not.toHaveLength(0);
     expect(wrapper.find('div')).not.toHaveLength(1);
   });


### PR DESCRIPTION
For the EventDetails component, show the event location on the map with a marker and label for the name of the venue. The label position isn't great right now as it overlaps the marker. I don't see anything in the [docs](https://developers.google.com/maps/documentation/javascript/3.exp/reference#MarkerLabel) that changes the marker label position, though.
Changes:
* Event epic - add `&expand=venue` to get event venue location.
   * Reference: [Expansions](https://www.eventbrite.com/developer/v3/api_overview/expansions/)
* Event reducer - Modify the event response to return the venue latitude and longitude in a nicer format to send to the SimpleMap component. Not sure if this is the best way (as it duplicates information), but it makes it easier to pass to the component. Venue latitude and longitude are not required so we might not have these.
  * Reference: [Venue](https://www.eventbrite.com/developer/v3/response_formats/venue/) response
* SimpleMap - Use venue coordinates if they are available.
  * [react-google-maps](https://github.com/tomchentw/react-google-maps)